### PR TITLE
Increase external-crates-test timeout to 75 minutes

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -49,7 +49,7 @@ jobs:
   external-crates-test:
     needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true'
-    timeout-minutes: 45
+    timeout-minutes: 75
     env:
       # Tests written with #[sim_test] are often flaky if run as #[tokio::test] - this var
       # causes #[sim_test] to only run under the deterministic `simtest` job, and not the


### PR DESCRIPTION
## Summary

`external-crates-test` takes ~43 minutes even on a healthy runner (42m34s on the PR #12 run that passed), leaving under 3 minutes of headroom against the current `timeout-minutes: 45` limit. Slightly slower runners hit the limit and the job is cancelled mid-run — this caused three spurious "Cancelled after 45m" results across PR #12 and the post-merge runs on main.

One-line change: raise the limit to 75 minutes so runner-speed variance stops cancelling an otherwise-passing job.

## Verification

- Change is CI-config only; no code affected. The `external-crates-test` run on this very PR exercises the new limit.