### PR TITLE
chore: bump workspace version to 1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,7 +2750,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "const-str",
  "git-version",
@@ -6470,7 +6470,7 @@ dependencies = [
 
 [[package]]
 name = "haneul"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6733,7 +6733,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-analytics-indexer"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -6792,7 +6792,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-analytics-indexer-derive"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6865,7 +6865,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-bridge"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "alloy",
  "alloy-multiprovider-strategy",
@@ -6924,7 +6924,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-bridge-cli"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7020,7 +7020,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-checkpoint-blob-indexer"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7051,7 +7051,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-cluster-test"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7325,7 +7325,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-default-config"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -7333,7 +7333,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-display"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7357,7 +7357,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-e2e-tests"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7494,7 +7494,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-faucet"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -7521,14 +7521,14 @@ dependencies = [
 
 [[package]]
 name = "haneul-field-count"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "haneul-field-count-derive",
 ]
 
 [[package]]
 name = "haneul-field-count-derive"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -7536,7 +7536,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-fork"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7595,7 +7595,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-framework-snapshot"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7639,7 +7639,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-futures"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -7699,7 +7699,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7732,7 +7732,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-consistent-api"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -7745,7 +7745,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-consistent-store"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7866,7 +7866,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-framework"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7915,7 +7915,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-framework-store-traits"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7927,7 +7927,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-graphql"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-jsonrpc"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8055,7 +8055,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-metrics"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -8070,7 +8070,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-object-store"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8084,7 +8084,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-reader"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8120,7 +8120,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-schema"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8136,7 +8136,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-inverted-index"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8348,7 +8348,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-kv-rpc"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8394,7 +8394,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-kvstore"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-light-client"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-metric-checker"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -8533,7 +8533,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-move"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -8580,7 +8580,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-move-build"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -8606,7 +8606,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-move-lsp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bin-version",
  "clap",
@@ -8721,7 +8721,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-name-service"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bcs",
  "haneul-types",
@@ -8788,7 +8788,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-node"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -8842,7 +8842,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-open-rpc"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8876,7 +8876,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-oracle"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8906,7 +8906,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-package-alt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-package-dump"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8941,7 +8941,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-package-management"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "haneul-framework-snapshot",
@@ -8974,7 +8974,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-pg-db"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9171,7 +9171,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rosetta"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9296,7 +9296,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-benchmark"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bb8",
@@ -9321,7 +9321,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-loadgen"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9348,7 +9348,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-resolver"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9367,7 +9367,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-sdk"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9431,7 +9431,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-security-watchdog"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9479,7 +9479,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-single-node-benchmark"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bcs",
  "clap",
@@ -9538,7 +9538,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-source-validation"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -9581,7 +9581,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-sql-macro"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -9647,7 +9647,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-surfer"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bcs",
  "clap",
@@ -9759,7 +9759,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-test-validator"
-version = "1.3.0"
+version = "1.3.1"
 
 [[package]]
 name = "haneul-tls"
@@ -9785,7 +9785,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-tool"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -20397,7 +20397,7 @@ dependencies = [
 
 [[package]]
 name = "x"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by haneul-core, haneul-faucet, haneul-node, haneul-tools, haneul-sdk, haneul-move-build, and haneul crates.
-version = "1.3.0"
+version = "1.3.1"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces


### PR DESCRIPTION
## Summary

One-line version bump (`Cargo.toml` workspace version 1.3.0 → 1.3.1) plus the corresponding `Cargo.lock` regeneration, so the node binary self-identifies as `1.3.1-<hash>` in version strings, logs, and the uptime metric — matching the `mainnet-v1.3.1` release that ships the telemetry removal (#12) and CI timeout fix (#13).

After merge, the `mainnet-v1.3.1` tag/release will be re-pointed to the merged commit (the tag has not been deployed or consumed yet).