### PR TITLE
fix: point v118 framework snapshot git_revision at a reachable commit

### DIFF
--- a/crates/haneul-framework-snapshot/manifest.json
+++ b/crates/haneul-framework-snapshot/manifest.json
@@ -90,7 +90,7 @@
     ]
   },
   "118": {
-    "git_revision": "127b3ca9d91878e18e0dd98374593a8d42fe0a47",
+    "git_revision": "a9fe199718fb9c9f25ae361af64dde0a36934029",
     "packages": [
       {
         "name": "MoveStdlib",


### PR DESCRIPTION
## Problem

`haneul move build` fails for every Move package targeting a v118 environment:

```
fatal: remote error: upload-pack: not our ref 127b3ca9d91878e18e0dd98374593a8d42fe0a47
```

The `"118"` entry in `crates/haneul-framework-snapshot/manifest.json` records `127b3ca9`, the HEAD of the protocol-upgrade working branch at the time the snapshot was taken. That commit no longer exists on the remote after the squash merge, but it is embedded into the CLI at build time (`haneul-package-management/build.rs`) and used to fetch the implicit framework dependencies (`Haneul`, `MoveStdlib`, ...), so dependency resolution is broken for all developers.

## Fix

Point the v118 entry at `a9fe1997`, the `mainnet-v1.3.1` tag commit.

Correctness:
- `git diff 6466a473 a9fe1997 -- crates/haneul-framework/packages/` is empty — the framework sources at this commit are identical to the v118 activation build, i.e. they match the on-chain framework exactly.
- The commit is permanently reachable through the release tag.

## Impact

Developer tooling only: the value feeds the CLI's implicit dependency resolution. Validators never consult it at runtime, so no node redeployment is required.

## Follow-up

Release SOP: after tagging a release that activates a new protocol version, update that version's `git_revision` in `manifest.json` to the tag commit, so squash merges can't orphan it again.