### PR TITLE
test: fix stale mainnet short id in test_chain_id_mainnet

### DIFF
--- a/crates/haneul-types/src/digests.rs
+++ b/crates/haneul-types/src/digests.rs
@@ -1183,7 +1183,7 @@ mod test {
         if has_env_override() {
             return;
         }
-        let chain_id = ChainIdentifier::from_chain_short_id(&String::from("35834a8a"));
+        let chain_id = ChainIdentifier::from_chain_short_id(&String::from("a0053d9e"));
         assert_eq!(
             chain_id.unwrap().chain(),
             haneul_protocol_config::Chain::Mainnet


### PR DESCRIPTION
## Summary

`test_chain_id_mainnet` in `crates/haneul-types/src/digests.rs` still queried an outdated short id (`35834a8a`). The mainnet chain identifier resolves to `a0053d9e`, so the lookup returned `None` and the test panicked on `unwrap()`.

This updates the test to query the current mainnet short id. One-line change, test-only — no runtime or consensus impact.

## Testing

`HANEUL_SKIP_SIMTESTS=1 cargo nextest run -p haneul-types test_chain_id`

- `test_chain_id_mainnet` — PASS (previously panicked)
- `test_chain_id_testnet` — PASS
- `test_chain_id_unknown` — PASS