### PR TITLE
tool: support self-hosted checkpoint archives in formal snapshot restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4093,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/haneul-tool/src/commands.rs
+++ b/crates/haneul-tool/src/commands.rs
@@ -4,8 +4,9 @@
 use crate::db_tool::{DbToolCommand, execute_db_tool_command, print_db_all_tables};
 use crate::{
     ConciseObjectOutput, GroupedObjectOutput, SnapshotVerifyMode, VerboseObjectOutput,
-    check_completed_snapshot, download_formal_snapshot, get_latest_available_epoch, get_object,
-    get_transaction_block, make_clients, restore_from_db_checkpoint,
+    check_completed_snapshot, download_formal_snapshot, generate_epochs_json,
+    get_latest_available_epoch, get_object, get_transaction_block, make_clients,
+    restore_from_db_checkpoint,
 };
 use anyhow::Result;
 use consensus_core::storage::{Store, rocksdb_store::RocksDBStore};
@@ -279,6 +280,38 @@ pub enum ToolCommand {
         /// Port for the Prometheus metrics server. Defaults to 9184.
         #[clap(long = "metrics-port", default_value = "9184")]
         metrics_port: u16,
+        /// URL of the checkpoint ingestion store used for checkpoint summary
+        /// sync and transaction digest backfill. If not specified, defaults
+        /// are based on the value of `--network`. Supports `https://`,
+        /// `s3://`, and `file://` URLs, e.g. `file:///path/to/checkpoints`
+        /// for a locally unpacked archive.
+        #[clap(long = "ingestion-url")]
+        ingestion_url: Option<String>,
+        /// First epoch whose end-of-epoch checkpoint is available in the
+        /// ingestion store. End-of-epoch checkpoints of earlier epochs are
+        /// neither fetched nor verified; the end-of-epoch checkpoint of this
+        /// epoch becomes the trust root for committee verification instead of
+        /// genesis. Only set this when restoring from an archive whose
+        /// checkpoint history starts after genesis.
+        #[clap(long = "start-epoch")]
+        start_epoch: Option<u64>,
+    },
+
+    /// Generate the `epochs.json` index required by a checkpoint ingestion
+    /// store, by scanning a local directory of `<seq>.binpb.zst` checkpoint
+    /// files (e.g. unpacked archive tars) for end-of-epoch checkpoints.
+    #[clap(name = "generate-epochs-json")]
+    GenerateEpochsJson {
+        /// Directory containing `<seq>.binpb.zst` checkpoint files.
+        #[clap(long = "ingestion-dir")]
+        ingestion_dir: PathBuf,
+        /// Output path for the generated index. Defaults to
+        /// `<ingestion-dir>/epochs.json`.
+        #[clap(long = "out")]
+        out: Option<PathBuf>,
+        /// Number of checkpoint files to read in parallel.
+        #[clap(long = "concurrency", default_value = "16")]
+        concurrency: usize,
     },
 
     #[clap(name = "replay")]
@@ -615,6 +648,8 @@ impl ToolCommand {
                 verbose,
                 max_retries,
                 metrics_port,
+                ingestion_url,
+                start_epoch,
             } => {
                 if !verbose {
                     tracing_handle
@@ -711,11 +746,13 @@ impl ToolCommand {
                     }
                 };
 
-                let ingestion_url = match network {
-                    Chain::Mainnet => "https://checkpoints.mainnet.haneul.io",
-                    Chain::Testnet => "https://checkpoints.testnet.haneul.io",
-                    _ => panic!("Cannot generate default ingestion url for unknown network"),
-                };
+                let ingestion_url = ingestion_url.unwrap_or_else(|| match network {
+                    Chain::Mainnet => "https://checkpoints.mainnet.haneul.io".to_string(),
+                    Chain::Testnet => "https://checkpoints.testnet.haneul.io".to_string(),
+                    _ => panic!(
+                        "--ingestion-url must be specified when --network is not mainnet or testnet"
+                    ),
+                });
 
                 let latest_available_epoch =
                     latest.then_some(get_latest_available_epoch(&snapshot_store_config).await?);
@@ -738,7 +775,8 @@ impl ToolCommand {
                     epoch_to_download,
                     &genesis,
                     snapshot_store_config,
-                    ingestion_url,
+                    &ingestion_url,
+                    start_epoch.unwrap_or(0),
                     num_parallel_downloads,
                     num_parallel_chunks,
                     network,
@@ -747,6 +785,14 @@ impl ToolCommand {
                     metrics_port,
                 )
                 .await?;
+            }
+            ToolCommand::GenerateEpochsJson {
+                ingestion_dir,
+                out,
+                concurrency,
+            } => {
+                let out = out.unwrap_or_else(|| ingestion_dir.join("epochs.json"));
+                generate_epochs_json(&ingestion_dir, &out, concurrency.max(1)).await?;
             }
             ToolCommand::Replay {
                 rpc_url,

--- a/crates/haneul-tool/src/lib.rs
+++ b/crates/haneul-tool/src/lib.rs
@@ -589,6 +589,7 @@ fn start_summary_sync(
     num_parallel_downloads: usize,
     verify: bool,
     end_of_epoch_checkpoint_seq_nums: Vec<u64>,
+    start_epoch: u64,
 ) -> JoinHandle<Result<(), anyhow::Error>> {
     tokio::spawn(async move {
         let store = AuthorityStore::open_no_genesis(perpetual_db, false, &Registry::default())?;
@@ -610,7 +611,17 @@ fn start_summary_sync(
             .last()
             .expect("Expected at least one checkpoint");
 
-        let num_to_sync = end_of_epoch_checkpoint_seq_nums.len() as u64;
+        // When the ingestion store's history starts after genesis, entries
+        // before `start_epoch` are placeholders for checkpoints that were
+        // never archived — they cannot be fetched.
+        let seq_nums_to_fetch: Vec<_> = end_of_epoch_checkpoint_seq_nums
+            .iter()
+            .enumerate()
+            .filter(|(cp_epoch, _)| *cp_epoch as u64 >= start_epoch)
+            .map(|(_, seq)| *seq)
+            .collect();
+
+        let num_to_sync = seq_nums_to_fetch.len() as u64;
         let sync_progress_bar = m.add(
             ProgressBar::new(num_to_sync).with_style(
                 ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})")
@@ -652,7 +663,7 @@ fn start_summary_sync(
             ingestion_url,
             num_parallel_downloads,
             state_sync_store.clone(),
-            end_of_epoch_checkpoint_seq_nums.clone(),
+            seq_nums_to_fetch,
             sync_checkpoint_counter,
         )
         .await?;
@@ -663,8 +674,17 @@ fn start_summary_sync(
             .get_checkpoint_by_sequence_number(*last_checkpoint)?
             .ok_or(anyhow!("Failed to read last checkpoint"))?;
         if verify {
+            // With a partial archive, the first available end-of-epoch
+            // checkpoint (epoch `start_epoch`) is the trust root: the
+            // checkpoint carrying the committee that signed it was never
+            // archived, so it cannot be verified and is trusted as-is.
+            let num_to_verify = if start_epoch > 0 {
+                num_to_sync.saturating_sub(1)
+            } else {
+                num_to_sync
+            };
             let verify_progress_bar = m.add(
-                ProgressBar::new(num_to_sync).with_style(
+                ProgressBar::new(num_to_verify).with_style(
                     ProgressStyle::with_template(
                         "[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})",
                     )
@@ -696,10 +716,14 @@ fn start_summary_sync(
             for (cp_epoch, epoch_last_cp_seq_num) in
                 end_of_epoch_checkpoint_seq_nums.iter().enumerate()
             {
+                let cp_epoch = cp_epoch as u64;
+                if start_epoch > 0 && cp_epoch <= start_epoch {
+                    continue;
+                }
                 let epoch_last_checkpoint = checkpoint_store
                     .get_checkpoint_by_sequence_number(*epoch_last_cp_seq_num)?
                     .ok_or(anyhow!("Failed to read checkpoint"))?;
-                let committee = state_sync_store.get_committee(cp_epoch as u64).expect(
+                let committee = state_sync_store.get_committee(cp_epoch).expect(
                     "Expected committee to exist after syncing all end of epoch checkpoints",
                 );
                 epoch_last_checkpoint
@@ -788,6 +812,7 @@ pub async fn download_formal_snapshot(
     genesis: &Path,
     snapshot_store_config: ObjectStoreConfig,
     ingestion_url: &str,
+    start_epoch: u64,
     num_parallel_downloads: usize,
     num_parallel_chunks: usize,
     network: Chain,
@@ -846,6 +871,30 @@ pub async fn download_formal_snapshot(
         .into_iter()
         .take((epoch + 1) as usize)
         .collect();
+    if end_of_epoch_checkpoint_seq_nums.len() != (epoch + 1) as usize {
+        return Err(anyhow!(
+            "epochs.json in the ingestion store lists {} end-of-epoch checkpoints, \
+            but restoring epoch {} requires {}",
+            end_of_epoch_checkpoint_seq_nums.len(),
+            epoch,
+            epoch + 1,
+        ));
+    }
+    if start_epoch > 0 {
+        // Transaction digest backfill needs the end-of-epoch checkpoints of
+        // both the target epoch and the epoch before it.
+        if start_epoch >= epoch {
+            return Err(anyhow!(
+                "--start-epoch {start_epoch} must be less than the target epoch {epoch}",
+            ));
+        }
+        let msg = format!(
+            "Ingestion store history starts at epoch {start_epoch}: its end-of-epoch \
+            checkpoint is trusted as the verification root; earlier epochs are skipped.",
+        );
+        m.println(&msg)?;
+        info!("{}", msg);
+    }
 
     let summaries_handle = start_summary_sync(
         perpetual_db.clone(),
@@ -857,6 +906,7 @@ pub async fn download_formal_snapshot(
         num_parallel_downloads,
         verify != SnapshotVerifyMode::None,
         end_of_epoch_checkpoint_seq_nums.clone(),
+        start_epoch,
     );
 
     // Start transaction backfill in parallel with summary sync
@@ -1064,6 +1114,113 @@ pub async fn download_formal_snapshot(
         epoch
     );
 
+    Ok(())
+}
+
+/// Scans a local directory of `<seq>.binpb.zst` checkpoint files for
+/// end-of-epoch checkpoints and writes the `epochs.json` index expected by
+/// checkpoint ingestion stores: a JSON array where entry `i` is the sequence
+/// number of epoch `i`'s last checkpoint. Epochs that ended before the first
+/// archived checkpoint get placeholder `0` entries; a restore over such an
+/// index must pass `--start-epoch`.
+pub async fn generate_epochs_json(
+    ingestion_dir: &Path,
+    out: &Path,
+    concurrency: usize,
+) -> Result<(), anyhow::Error> {
+    let mut seq_nums: Vec<u64> = fs::read_dir(ingestion_dir)?
+        .filter_map(|entry| {
+            let name = entry.ok()?.file_name().into_string().ok()?;
+            name.strip_suffix(".binpb.zst")?.parse().ok()
+        })
+        .collect();
+    seq_nums.sort_unstable();
+    let (first, last) = match (seq_nums.first(), seq_nums.last()) {
+        (Some(first), Some(last)) => (*first, *last),
+        _ => {
+            return Err(anyhow!(
+                "no <seq>.binpb.zst checkpoint files found in {}",
+                ingestion_dir.display()
+            ));
+        }
+    };
+    if let Some(w) = seq_nums.windows(2).find(|w| w[1] != w[0] + 1) {
+        return Err(anyhow!(
+            "gap in archived checkpoints: {} is followed by {}",
+            w[0],
+            w[1]
+        ));
+    }
+    println!(
+        "Scanning {} checkpoints ({first}..={last}) for end-of-epoch checkpoints",
+        seq_nums.len()
+    );
+
+    let progress_bar = ProgressBar::new(seq_nums.len() as u64).with_style(
+        ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})").unwrap(),
+    );
+    let dir = ingestion_dir.canonicalize()?;
+    let store = build_object_store(&format!("file://{}", dir.display()), vec![]);
+    let boundaries: BTreeMap<u64, u64> = futures::stream::iter(seq_nums)
+        .map(|seq| {
+            let store = store.clone();
+            let progress_bar = progress_bar.clone();
+            async move {
+                let checkpoint = fetch_checkpoint(&store, seq).await?;
+                progress_bar.inc(1);
+                let summary = checkpoint.summary.data();
+                Ok::<_, anyhow::Error>(
+                    summary
+                        .end_of_epoch_data
+                        .as_ref()
+                        .map(|_| (summary.epoch, seq)),
+                )
+            }
+        })
+        .buffer_unordered(concurrency)
+        .try_filter_map(|entry| futures::future::ready(Ok(entry)))
+        .try_collect()
+        .await?;
+    progress_bar.finish_with_message("scan complete");
+
+    let (first_epoch, last_epoch) = match (boundaries.keys().next(), boundaries.keys().last()) {
+        (Some(first_epoch), Some(last_epoch)) => (*first_epoch, *last_epoch),
+        _ => {
+            return Err(anyhow!(
+                "no end-of-epoch checkpoints found in {} — the archive covers \
+                less than one full epoch",
+                ingestion_dir.display()
+            ));
+        }
+    };
+    // A contiguous checkpoint range must yield a contiguous epoch range.
+    if boundaries.len() as u64 != last_epoch - first_epoch + 1 {
+        return Err(anyhow!(
+            "end-of-epoch checkpoints are not contiguous: expected epochs \
+            {first_epoch}..={last_epoch}, found {}",
+            boundaries.keys().join(", ")
+        ));
+    }
+
+    let mut epochs = vec![0u64; (last_epoch + 1) as usize];
+    for (epoch, seq) in &boundaries {
+        epochs[*epoch as usize] = *seq;
+    }
+    fs::write(out, serde_json::to_vec(&epochs)?)?;
+    println!(
+        "Wrote {} entries to {}: epochs {first_epoch}..={last_epoch} have real \
+        end-of-epoch checkpoints{}",
+        epochs.len(),
+        out.display(),
+        if first_epoch > 0 {
+            format!(
+                "; entries 0..={} are placeholders — restore with --start-epoch {first_epoch}",
+                first_epoch - 1
+            )
+        } else {
+            String::new()
+        },
+    );
     Ok(())
 }
 

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Makes `haneul-tool download-formal-snapshot` usable against the mainnet S3 archive bucket, which stores checkpoint history as batched tars starting at epoch 104 rather than as a per-checkpoint public endpoint.

- **`--ingestion-url`**: overrides the per-network default checkpoint store URL. Accepts `https://`, `s3://`, and `file://` (e.g. a locally unpacked archive directory). Defaults unchanged.
- **`--start-epoch`**: supports archives whose checkpoint history starts after genesis. The first archived end-of-epoch checkpoint becomes the trust root for committee verification; placeholder `epochs.json` entries before it are neither fetched nor verified. Committee chain verification for all later epochs is unchanged. Omitting the flag preserves existing behavior exactly.
- **`generate-epochs-json`** (new subcommand): scans a local directory of `<seq>.binpb.zst` checkpoint files for end-of-epoch checkpoints and writes the `epochs.json` index that ingestion stores must serve. Validates checkpoint continuity (gap detection) and epoch continuity, and prints the `--start-epoch` value to use when the history is partial.

Also adds an early, clear error when `epochs.json` lists fewer epochs than the restore target requires (previously failed later with a less obvious message).

## Why

Restore drills against the `haneul-archive-mainnet` bucket need these: the default ingestion URLs point at endpoints we do not operate, and pre-epoch-104 checkpoint history does not exist in the archive. This tooling is the disaster-recovery path for rebuilding a node from S3 alone.

## Test plan

- `cargo check -p haneul-tool` clean
- `cargo xclippy` (haneul-tool) clean, `cargo fmt --check` clean
- No callers of the changed functions outside this crate
- End-to-end exercise happens in the restore drill: unpack archive tars, `generate-epochs-json`, then `download-formal-snapshot --ingestion-url file://... --start-epoch 104` and boot a fullnode from the result