### PR TITLE
fix(keys): use registered coin type 8282 in key derivation paths

### DIFF
--- a/crates/haneul-keys/src/key_derive.rs
+++ b/crates/haneul-keys/src/key_derive.rs
@@ -19,7 +19,10 @@ use haneul_types::{
 };
 use slip10_ed25519::derive_ed25519_private_key;
 
-pub const DERIVATION_PATH_COIN_TYPE: u32 = 784;
+// SLIP-0044 registered coin type for HANEUL. Must match the TypeScript SDK's
+// default derivation paths (m/44'/8282'/... etc.) so the same mnemonic resolves
+// to the same address across all tooling.
+pub const DERIVATION_PATH_COIN_TYPE: u32 = 8282;
 pub const DERVIATION_PATH_PURPOSE_ED25519: u32 = 44;
 pub const DERVIATION_PATH_PURPOSE_SECP256K1: u32 = 54;
 pub const DERVIATION_PATH_PURPOSE_SECP256R1: u32 = 74;

--- a/crates/haneul/src/client_ptb/snapshots/haneul__client_ptb__parser__tests__parse_commands.snap
+++ b/crates/haneul/src/client_ptb/snapshots/haneul__client_ptb__parser__tests__parse_commands.snap
@@ -778,13 +778,13 @@ expression: parsed
                 Spanned {
                     span: Span {
                         start: 0,
-                        end: 71,
+                        end: 74,
                     },
                     value: MoveCall(
                         Spanned {
                             span: Span {
                                 start: 12,
-                                end: 46,
+                                end: 49,
                             },
                             value: ModuleAccess {
                                 address: Spanned {
@@ -799,7 +799,7 @@ expression: parsed
                                 module_name: Spanned {
                                     span: Span {
                                         start: 17,
-                                        end: 27,
+                                        end: 30,
                                     },
                                     value: Identifier(
                                         "haneul_system",
@@ -807,8 +807,8 @@ expression: parsed
                                 },
                                 function_name: Spanned {
                                     span: Span {
-                                        start: 29,
-                                        end: 46,
+                                        start: 32,
+                                        end: 49,
                                     },
                                     value: Identifier(
                                         "request_add_stake",
@@ -820,8 +820,8 @@ expression: parsed
                         [
                             Spanned {
                                 span: Span {
-                                    start: 47,
-                                    end: 53,
+                                    start: 50,
+                                    end: 56,
                                 },
                                 value: Identifier(
                                     "system",
@@ -829,22 +829,22 @@ expression: parsed
                             },
                             Spanned {
                                 span: Span {
-                                    start: 54,
-                                    end: 61,
+                                    start: 57,
+                                    end: 64,
                                 },
                                 value: VariableAccess(
                                     Spanned {
                                         span: Span {
-                                            start: 54,
-                                            end: 59,
+                                            start: 57,
+                                            end: 62,
                                         },
                                         value: "coins",
                                     },
                                     [
                                         Spanned {
                                             span: Span {
-                                                start: 60,
-                                                end: 61,
+                                                start: 63,
+                                                end: 64,
                                             },
                                             value: "0",
                                         },
@@ -853,8 +853,8 @@ expression: parsed
                             },
                             Spanned {
                                 span: Span {
-                                    start: 62,
-                                    end: 71,
+                                    start: 65,
+                                    end: 74,
                                 },
                                 value: Identifier(
                                     "validator",
@@ -879,8 +879,8 @@ expression: parsed
             gas_budget: Some(
                 Spanned {
                     span: Span {
-                        start: 72,
-                        end: 86,
+                        start: 75,
+                        end: 89,
                     },
                     value: 1,
                 },

--- a/crates/haneul/src/client_ptb/snapshots/haneul__client_ptb__parser__tests__parse_mvr_names_invalid.snap
+++ b/crates/haneul/src/client_ptb/snapshots/haneul__client_ptb__parser__tests__parse_mvr_names_invalid.snap
@@ -39,8 +39,8 @@ expression: parsed
     PTBError {
         message: "Invalid MVR package reference",
         span: Span {
-            start: 7,
-            end: 7,
+            start: 10,
+            end: 10,
         },
         help: Some(
             "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.haneul)/<package>[/<version>]'",

--- a/crates/haneul/src/client_ptb/snapshots/haneul__client_ptb__parser__tests__parse_types.snap
+++ b/crates/haneul/src/client_ptb/snapshots/haneul__client_ptb__parser__tests__parse_types.snap
@@ -71,7 +71,7 @@ expression: parsed
     Spanned {
         span: Span {
             start: 0,
-            end: 15,
+            end: 18,
         },
         value: Struct(
             ParsedStructType {
@@ -111,7 +111,7 @@ expression: parsed
     Spanned {
         span: Span {
             start: 0,
-            end: 26,
+            end: 29,
         },
         value: Struct(
             ParsedStructType {
@@ -131,7 +131,7 @@ expression: parsed
     Spanned {
         span: Span {
             start: 0,
-            end: 28,
+            end: 34,
         },
         value: Struct(
             ParsedStructType {
@@ -166,7 +166,7 @@ expression: parsed
     Spanned {
         span: Span {
             start: 0,
-            end: 68,
+            end: 74,
         },
         value: Struct(
             ParsedStructType {

--- a/crates/haneul/src/unit_tests/keytool_tests.rs
+++ b/crates/haneul/src/unit_tests/keytool_tests.rs
@@ -314,18 +314,18 @@ async fn test_mnemonics_ed25519() -> Result<(), anyhow::Error> {
     const TEST_CASES: [[&str; 3]; 3] = [
         [
             "film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm",
-            "haneulprivkey1qrwsjvr6gwaxmsvxk4cfun99ra8uwxg3c9pl0nhle7xxpe4s80y055uhy8u",
-            "a2d14fad60c56049ecf75246a481934691214ce413e6a8ae2fe6834c173a6133",
+            "haneulprivkey1qq3denfafqukqq787x2lm3w0xz6l7ervh972qd5qpg6jpatgj0nlqpkkfd5",
+            "055c03c8c3403919d4e09932dcdda72a2fc82bfe3271f997757eb3b4da7bb1c6",
         ],
         [
             "require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level",
-            "haneulprivkey1qzdvpa77ct272ultqcy20dkw78dysnfyg90fhcxkdm60el0qht9mvwg63td",
-            "1ada6e6f3f3e4055096f606c746690f1108fcc2ca479055cc434a3e1d3f758aa",
+            "haneulprivkey1qzr34yn7lwexhmqdk8tpmqc9kym66spt7emeu0jkqsfa5hk0w5kgxwsw34p",
+            "6f86f3c584f9a645691bf1003eb6a1e4fdb6dda4c61548d2f6ebd4994233bc62",
         ],
         [
             "organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake",
-            "haneulprivkey1qqqscjyyr64jea849dfv9cukurqj2swx0m3rr4hr7sw955jy07tzg56njz5",
-            "e69e896ca10f5a77732769803cc2b5707f0ab9d4407afb5e4b4464b89769af14",
+            "haneulprivkey1qqljwx0h9wq07sujftzygpacxwmkdws08apggv5068vrfpahspzzstnanhk",
+            "18ee8052cb5152c86a472be66075fefd44f7d1bb041b48a5a08b9b65e9f1612a",
         ],
     ];
 
@@ -354,18 +354,18 @@ async fn test_mnemonics_secp256k1() -> Result<(), anyhow::Error> {
     const TEST_CASES: [[&str; 3]; 3] = [
         [
             "film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm",
-            "haneulprivkey1qyqr6yvxdqkh32ep4pk9caqvphmk9epn6rhkczcrhaeermsyvwsg7txwrry",
-            "9e8f732575cc5386f8df3c784cd3ed1b53ce538da79926b2ad54dcc1197d2532",
+            "haneulprivkey1qyxagt2a78lc0s3328xeq0nltyqpyda0vq0t4taq5dmpv645a4wnkvnxy9u",
+            "3324c73fa34509db8d0baaf389a412449509629bdb06d826fbfb50082e6f8b6e",
         ],
         [
             "require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level",
-            "haneulprivkey1q8hexn5m2u36tx39ln5e22hfseadknp7d2qlkhe30ejy7fc6am5aq6htxwd",
-            "9fd5a804ed6b46d36949ff7434247f0fd594673973ece24aede6b86a7b5dae01",
+            "haneulprivkey1qxt9wll7mf06nl23ftvewtm9stmvrxvhuzdgq4fph9xljat0zsgm6ccaanc",
+            "eb8e733513c797118e0cbca10eafa77fb31c9fe8f74eeb931cf351280a642617",
         ],
         [
             "organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake",
-            "haneulprivkey1qxx6yf53jgxvsmccst8cuwnj0rx4k4uzvn9aalvag7ns0xf0g8j2xxzs5w5",
-            "60287d7c38dee783c2ab1077216124011774be6b0764d62bd05f32c88979d5c5",
+            "haneulprivkey1q9l4ucn5hj2w2mj3v4f5h6qng070j2drd5wgt22frk0jq3ar828sgdlwkjq",
+            "6cc36ff91ffc4170d818c81e821988a8360a720b49150702105836cbfa18bd30",
         ],
     ];
 
@@ -394,18 +394,18 @@ async fn test_mnemonics_secp256r1() -> Result<(), anyhow::Error> {
     const TEST_CASES: [[&str; 3]; 3] = [
         [
             "act wing dilemma glory episode region allow mad tourist humble muffin oblige",
-            "haneulprivkey1qgj6vet4rstf2p00j860xctkg4fyqqq5hxgu4mm0eg60fq787ujnqury7el",
-            "0x4a822457f1970468d38dae8e63fb60eefdaa497d74d781f581ea2d137ec36f3a",
+            "haneulprivkey1qfw9yd23qca85dywwp2gc2fkjv766xe44370r8rsttaul77sn5g22vf6fch",
+            "0x8dca749c89a17aba44abf789e3b82974e85036102917a572406406164d8ec069",
         ],
         [
             "flag rebel cabbage captain minimum purpose long already valley horn enrich salt",
-            "haneulprivkey1qgmgr6dza8slgxn0rcxcy47xeas9l565cc5q440ngdzr575rc2356y44xqz",
-            "0xcd43ecb9dd32249ff5748f5e4d51855b01c9b1b8bbe7f8638bb8ab4cb463b920",
+            "haneulprivkey1q2qgrcj0k5vdhy25fzcgncfl3slc6lvpvq08yspzdtvxj53qxnyqjf5xpte",
+            "0x2cc08866814b783f84c29f5aa387c8f63c88a8c2f34a3a7adc7fbf805c687ee7",
         ],
         [
             "area renew bar language pudding trial small host remind supreme cabbage era",
-            "haneulprivkey1qt2gsye4dyn0lxey0ht6d5f2ada7ew9044a49y2f3mymy2uf0hr557vry8w",
-            "0x0d9047b7e7b698cc09c955ea97b0c68c2be7fb3aebeb59edcc84b1fb87e0f28e",
+            "haneulprivkey1q285mtvz4z4rjhmrf09s44rg2z5u8jw42utv4x46v7mm8jt5r9fx7uau5en",
+            "0x7af553c91a78621cb73fcd5175b6ed43b7b80def8b771759db89c1c3bb14b91d",
         ],
     ];
 


### PR DESCRIPTION
## Summary
- `DERIVATION_PATH_COIN_TYPE` was `784`, contradicting the coin type documented in the CLI help, the SLIP-0044 registration, and the TypeScript SDK defaults (`m/44'/8282'/...` family). The same mnemonic therefore resolved to different addresses in the CLI vs the SDK.
- Set the constant to the registered value `8282` and regenerate the keytool mnemonic fixtures for the new default paths (9 vectors across ed25519 / secp256k1 / secp256r1, derived with the repo's own `derive_key_pair_from_path`).
- Separately, refresh three stale `client_ptb` parser snapshots (span offsets only) that were failing before this change.

## Impact
- Client-side only: no consensus, wire-format, or node-runtime change. On-chain state and keystore-stored raw keys are unaffected.
- Mnemonic-based re-derivation changes: a mnemonic now resolves to the `8282`-path address (matching the SDK), and `784` paths are rejected by path validation. Key inventory was audited beforehand — no wallet relies on mnemonic-only recovery.

## Testing
- `cargo nextest run -p haneul-keys -p haneul --lib --no-fail-fast`: **88/88 passed** (previously `test_valid_derivation_path` and the three mnemonic vector tests could not pass against the old constant).
- `cargo xclippy` (haneul-keys): clean. `cargo fmt --all -- --check`: clean.