### PR TITLE
ci: run core crate unit tests on every pull request

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,6 +75,39 @@ jobs:
       - name: Git checks
         run: scripts/git-checks.sh
 
+  # Runs on every PR (unlike `test`, which is workflow_dispatch-only because the
+  # full suite does not fit hosted runners). Scoped to core-crate unit tests so
+  # regressions in key handling, config, and protocol logic are caught before
+  # merge instead of at the next manual full run.
+  unit-tests:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
+    timeout-minutes: 90
+    env:
+      # Tests written with #[sim_test] are often flaky if run as #[tokio::test] - this var
+      # causes #[sim_test] to only run under the deterministic `simtest` job.
+      HANEUL_SKIP_SIMTESTS: 1
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        with:
+          ref: ${{ github.event.inputs.haneul_repo_ref || github.ref }}
+      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@protoc
+      - name: Free disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
+        with:
+          swap-size-gb: 10
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # pin@v2
+      - name: cargo nextest (core unit tests)
+        run: |
+          cargo nextest run --profile ci --lib -p haneul -p haneul-keys -p haneul-types -p haneul-config -p haneul-protocol-config -p shared-crypto
+      # Ensure there are no uncommitted changes in the repo after running tests
+      - run: scripts/changed-files.sh
+        shell: bash
+
   test:
     needs: [diff, rustfmt, clippy]
     if: github.event_name == 'workflow_dispatch' && needs.diff.outputs.isRust == 'true'


### PR DESCRIPTION
## Summary
- PR CI currently runs only lint-class gates (clippy, rustfmt, license, cargo-deny): every nextest job is gated behind `workflow_dispatch`, so no unit test executes on pull requests. This is how the derivation-path constant mismatch and the stale parser snapshots fixed in #21 stayed invisible — the covering tests existed but were never run.
- Adds a `unit-tests` job that runs on every PR (no manual gate), scoped to `--lib` tests of the core crates: `haneul`, `haneul-keys`, `haneul-types`, `haneul-config`, `haneul-protocol-config`, `shared-crypto`.

## Design
- `needs: diff` only → runs in parallel with clippy/rustfmt instead of behind them.
- Follows existing job conventions: pinned checkout, `taiki-e/install-action` for nextest/protoc, `HANEUL_SKIP_SIMTESTS: 1`, 10 GB swap step, trailing `changed-files.sh` cleanliness check.
- Adds `Swatinem/rust-cache` (pinned to the `v2` tag commit) so subsequent PR runs reuse the dependency build, plus a disk-space step (drops preinstalled dotnet/android/ghc) for headroom on hosted runners.
- Full suite / simtest jobs stay `workflow_dispatch`-only, unchanged.

## Testing
- Exact CI command verified locally: `cargo nextest run --profile ci --lib -p haneul -p haneul-keys -p haneul-types -p haneul-config -p haneul-protocol-config -p shared-crypto` → **425/425 passed**.
- Workflow YAML parse-checked; this PR itself is the first live run of the new job — check its wall-clock in the checks tab before merging and we can tune scope/cache if needed.