### PR TITLE
fix(name-service): point mainnet config at the deployed HaneulNS objects

### DIFF
--- a/crates/haneul-name-service/src/lib.rs
+++ b/crates/haneul-name-service/src/lib.rs
@@ -223,11 +223,11 @@ impl NameServiceConfig {
     // Create a config based on the package and object ids published on mainnet
     pub fn mainnet() -> Self {
         const MAINNET_NS_PACKAGE_ADDRESS: &str =
-            "0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0";
+            "0x047dfbd82298ec1c2c70b5743a8c4a00614ff864a580069c635f2dad3a7c76fa";
         const MAINNET_NS_REGISTRY_ID: &str =
-            "0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106";
+            "0xf539703ae28a9f324729506626766909f800a7e40ec90c6f2c8e865103d96525";
         const MAINNET_NS_REVERSE_REGISTRY_ID: &str =
-            "0x2fd099e17a292d2bc541df474f9fafa595653848cbabb2d7a4656ec786a1969f";
+            "0x60b38f5be27728c4c2e8861cf4213e9841c2ed0807236ffc583f4980af73f773";
 
         let package_address = HaneulAddress::from_str(MAINNET_NS_PACKAGE_ADDRESS).unwrap();
         let registry_id = ObjectID::from_str(MAINNET_NS_REGISTRY_ID).unwrap();

--- a/examples/prod-config/graphql.toml
+++ b/examples/prod-config/graphql.toml
@@ -24,9 +24,9 @@ max-disassembled-module-size = 1048576
 max-checkpoint-lag-ms = 300000
 
 [name-service]
-package-address = "0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0"
-registry-id = "0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106"
-reverse-registry-id = "0x2fd099e17a292d2bc541df474f9fafa595653848cbabb2d7a4656ec786a1969f"
+package-address = "0x047dfbd82298ec1c2c70b5743a8c4a00614ff864a580069c635f2dad3a7c76fa"
+registry-id = "0xf539703ae28a9f324729506626766909f800a7e40ec90c6f2c8e865103d96525"
+reverse-registry-id = "0x60b38f5be27728c4c2e8861cf4213e9841c2ed0807236ffc583f4980af73f773"
 
 [watermark]
 watermark-polling-interval-ms = 500


### PR DESCRIPTION
## Summary

The mainnet `NameServiceConfig` (crates/haneul-name-service/src/lib.rs) still carried upstream object ids that do not exist on this network. As a result every name-resolution surface silently returned empty results: JSON-RPC `haneulx_resolveNameServiceAddress` / `haneulx_resolveNameServiceNames`, gRPC `NameService`, and the GraphQL name fields.

This PR replaces the three ids with the HaneulNS deployment (2026-07-13):

| Field | New value |
|---|---|
| package_address | `0x047dfbd82298ec1c2c70b5743a8c4a00614ff864a580069c635f2dad3a7c76fa` |
| registry_id | `0xf539703ae28a9f324729506626766909f800a7e40ec90c6f2c8e865103d96525` |
| reverse_registry_id | `0x60b38f5be27728c4c2e8861cf4213e9841c2ed0807236ffc583f4980af73f773` |

The same three ids are updated in `examples/prod-config/graphql.toml`. All consumers (haneul-node, haneul-rpc-api, indexer JSON-RPC, GraphQL) resolve through `NameServiceConfig::mainnet()` / `default()`, so this single edit covers every surface; no other occurrence of the old ids remains in the repo.

## On-chain verification (public RPC, read-only)

- The registry table currently holds 11 name records. Querying the registry table for `hum.haneul` with the exact dynamic-field derivation this crate uses returns a `Field<Domain, NameRecord>` of the expected type, so name-to-address resolution goes live as soon as a binary with this change is rolled out.
- Current node behavior confirmed dead before the change: `haneulx_resolveNameServiceAddress("hum.haneul")` returns `null` while the record demonstrably exists on chain.

## Notes for future work (read before building on this)

1. **Reverse lookups will be empty at first, and that is correct.** The `reverse_registry` table is size 0 today: address-to-name records are opt-in and only appear after a name owner calls `set_reverse_lookup` (a single ns-ops transaction can set `hum.haneul` as the showcase record). An empty response from `resolveNameServiceNames` is therefore expected behavior, not a bug in this change.
2. **testnet() is intentionally untouched.** HaneulNS is not deployed on that network, so the testnet constants still point at nonexistent objects. Revisit only if a testnet deployment happens.

## Testing

- cargo check -p haneul-name-service: clean
- cargo xclippy (haneul-name-service): clean
- cargo nextest run -p haneul-name-service: 6/6 passed
- No config snapshots serialize these ids (verified by repo-wide grep of old and new values)