### PR TITLE
chore: bump workspace version to 1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,7 +2750,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "const-str",
  "git-version",
@@ -6470,7 +6470,7 @@ dependencies = [
 
 [[package]]
 name = "haneul"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6735,7 +6735,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-analytics-indexer"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-analytics-indexer-derive"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6867,7 +6867,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-bridge"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "alloy",
  "alloy-multiprovider-strategy",
@@ -6926,7 +6926,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-bridge-cli"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7022,7 +7022,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-checkpoint-blob-indexer"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7052,7 +7052,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-cluster-test"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7118,7 +7118,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-consistent-store"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7366,7 +7366,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-display"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7390,7 +7390,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-e2e-tests"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-faucet"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -7555,14 +7555,14 @@ dependencies = [
 
 [[package]]
 name = "haneul-field-count"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "haneul-field-count-derive",
 ]
 
 [[package]]
 name = "haneul-field-count-derive"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -7570,7 +7570,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-fork"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7629,7 +7629,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-framework-snapshot"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7673,7 +7673,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-futures"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7765,7 +7765,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-consistent-api"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -7778,7 +7778,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-consistent-store"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7900,7 +7900,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-framework"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7949,7 +7949,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-framework-store-traits"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7961,7 +7961,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-graphql"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8030,7 +8030,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-jsonrpc"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8091,7 +8091,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-metrics"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -8106,7 +8106,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-object-store"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8120,7 +8120,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-reader"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8157,7 +8157,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-schema"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8173,7 +8173,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-inverted-index"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8387,7 +8387,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-kv-rpc"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8433,7 +8433,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-kvstore"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8484,7 +8484,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-light-client"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8534,7 +8534,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-metric-checker"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -8571,7 +8571,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-move"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -8618,7 +8618,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-move-build"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -8644,7 +8644,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-move-lsp"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "bin-version",
  "clap",
@@ -8759,7 +8759,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-name-service"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "bcs",
  "haneul-types",
@@ -8826,7 +8826,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-node"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -8883,7 +8883,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-open-rpc"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8917,7 +8917,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-oracle"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8947,7 +8947,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-package-alt"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8966,7 +8966,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-package-dump"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8982,7 +8982,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-package-management"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "haneul-framework-snapshot",
@@ -9015,7 +9015,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-pg-db"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9055,7 +9055,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-prompt"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -9226,7 +9226,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rosetta"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9349,7 +9349,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-benchmark"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "bb8",
@@ -9386,7 +9386,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-loadgen"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9413,7 +9413,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-resolver"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9432,7 +9432,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-store"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9463,7 +9463,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-sdk"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9527,7 +9527,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-security-watchdog"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9575,7 +9575,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-single-node-benchmark"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "bcs",
  "clap",
@@ -9634,7 +9634,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-source-validation"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -9677,7 +9677,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-sql-macro"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -9743,7 +9743,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-surfer"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "bcs",
  "clap",
@@ -9856,7 +9856,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-test-validator"
-version = "1.5.0"
+version = "1.5.1"
 
 [[package]]
 name = "haneul-tls"
@@ -9882,7 +9882,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-tool"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -20533,7 +20533,7 @@ dependencies = [
 
 [[package]]
 name = "x"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by haneul-core, haneul-faucet, haneul-node, haneul-tools, haneul-sdk, haneul-move-build, and haneul crates.
-version = "1.5.0"
+version = "1.5.1"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/haneul-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
+++ b/crates/haneul-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/HaneulLabs/haneul/main/LICENSE"
     },
-    "version": "1.5.0"
+    "version": "1.5.1"
   },
   "methods": [
     {


### PR DESCRIPTION
Bumps the workspace version from 1.5.0 to 1.5.1 ahead of the mainnet-v1.5.1 release tag, so released binaries report themselves as haneul 1.5.1.

## Changes
- `Cargo.toml`: workspace version 1.5.0 -> 1.5.1
- `Cargo.lock`: workspace member entries synced via `cargo update --workspace` (no external dependency changes)
- `haneul-open-rpc` spec snapshot regenerated for the new version string (single-line diff)

## Verification
- `cargo nextest run -p haneul-open-rpc`: 2/2 passed (includes `test_version_matching`)