### PR TITLE
docs: overhaul root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The surest path to reaching this goal was to start from technology that had alre
 
 **Haneul is:**
 
-- **An object-centric blockchain**: Every asset is an object with an explicit owner, not a balance entry under an account. Transactions that touch disjoint objects execute in parallel, and transactions on single-owner objects are finalized without waiting for global ordering.
-- **Programmed in Move**: Smart contracts are written in Move, a language that guarantees at the type level that assets cannot be duplicated or accidentally destroyed.
-- **Secured by delegated proof of stake**: The DAG-based Mysticeti consensus provides sub-second finality. The native token HANEUL serves as both gas and the stake that secures the validator set.
-- **Built for everyday users**: The protocol supports zkLogin, so people can own on-chain assets with their existing web accounts, and sponsored transactions, so applications can pay gas on their users' behalf.
+- **An object-centric blockchain**: Every asset is an object with an explicit owner, and transactions that touch different objects execute in parallel.
+- **Programmed in Move**: A language that guarantees at the type level that assets cannot be duplicated or accidentally destroyed.
+- **Secured by delegated proof of stake**: The DAG-based Mysticeti consensus provides sub-second finality, with the native token HANEUL serving as both gas and stake.
+- **Built for everyday users**: The protocol supports zkLogin, for signing in with existing web accounts, and sponsored transactions, so applications can pay gas for their users.
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Haneul's mission is to create a financial network built on trust, where hundreds
 
 The surest path to reaching this goal was to start from technology that had already been designed and proven to hold up at that scale. Haneul began its development based on the Sui codebase created by Mysten Labs, and has deep respect for their outstanding engineering.
 
+**Haneul is:**
+
+- **An object-centric blockchain**: Every asset is an object with an explicit owner, not a balance entry under an account. Transactions that touch disjoint objects execute in parallel, and transactions on single-owner objects are finalized without waiting for global ordering.
+- **Programmed in Move**: Smart contracts are written in Move, a language that guarantees at the type level that assets cannot be duplicated or accidentally destroyed.
+- **Secured by delegated proof of stake**: The DAG-based Mysticeti consensus provides sub-second finality. The native token HANEUL serves as both gas and the stake that secures the validator set.
+- **Built for everyday users**: The protocol supports zkLogin, so people can own on-chain assets with their existing web accounts, and sponsored transactions, so applications can pay gas on their users' behalf.
+
 [![Github release](https://img.shields.io/github/v/release/GeunhwaJeong/haneul.svg?sort=semver)](https://github.com/GeunhwaJeong/haneul/releases/latest)
 [![License](https://img.shields.io/github/license/GeunhwaJeong/haneul)](https://github.com/GeunhwaJeong/haneul/blob/main/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 # Haneul
 
-Haneul Core implements a decentralized, programmable distributed ledger which provides a digital infrastructure that can empower billions of people.
+Haneul's mission is to create a financial network built on trust, where hundreds of millions of people can own and transact their money and digital assets directly, without intermediaries. Owning and trading assets inside the services you use every day, without ever having to be aware of the blockchain: that is what Haneul is aiming for. To achieve this, Haneul is designed to handle everyday transactions at that scale through an object-centric data model, the Move language, and parallel execution.
+
+The surest path to reaching this goal was to start from technology that had already been designed and proven to hold up at that scale. Haneul began its development based on the Sui codebase created by Mysten Labs, and has deep respect for their outstanding engineering.
 
 [![Github release](https://img.shields.io/github/v/release/GeunhwaJeong/haneul.svg?sort=semver)](https://github.com/GeunhwaJeong/haneul/releases/latest)
 [![License](https://img.shields.io/github/license/GeunhwaJeong/haneul)](https://github.com/GeunhwaJeong/haneul/blob/main/LICENSE)
@@ -93,6 +95,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE) for details.
-
-This project is originally derived from [Sui](https://github.com/MystenLabs/sui) by [Mysten Labs](https://mystenlabs.com), licensed under Apache-2.0.
+See the [LICENSE](LICENSE) file for more details.

--- a/README.md
+++ b/README.md
@@ -79,18 +79,24 @@ The faucet grants test HANEUL, and `client gas` lists the coin objects your addr
 
 ## Testing
 
+Most tests are ordinary Rust tests, run through [cargo-nextest](https://nexte.st/):
+
 ```bash
-# Unit tests
 HANEUL_SKIP_SIMTESTS=1 cargo nextest run
 
-# Test specific crate
+# or just one crate
 cargo nextest run -p haneul-core
+```
 
-# Simulation tests
+Consensus and end-to-end tests additionally run under a deterministic simulator that controls time and the network, so that distributed-systems bugs reproduce reliably instead of flaking. These must go through `cargo simtest`:
+
+```bash
 cargo simtest -p haneul-e2e-tests
 ```
 
 ## Linting
+
+`cargo xclippy` is the workspace's clippy wrapper with our lint configuration. CI runs both of these, so running them before pushing saves a round trip:
 
 ```bash
 cargo fmt --all
@@ -98,6 +104,8 @@ cargo xclippy
 ```
 
 ## Project Structure
+
+The repository is one large Cargo workspace. A map of the places you are most likely to visit:
 
 ```
 haneul/

--- a/README.md
+++ b/README.md
@@ -91,7 +91,18 @@ haneul/
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Thank you for considering helping out with the source code! We welcome contributions from anyone on the internet, and are grateful for even the smallest of fixes!
+
+If you'd like to contribute to Haneul, please fork, fix, commit and send a pull request for the maintainers to review and merge into the main code base. If you wish to submit more complex changes though, please [open an issue](https://github.com/GeunhwaJeong/haneul/issues) first to ensure those changes are in line with the general philosophy of the project and/or get some early feedback which can make both your efforts much lighter as well as our review and merge procedures quick and simple.
+
+Please make sure your contributions adhere to our coding guidelines:
+
+* Code must be formatted with `cargo fmt` and must pass `cargo xclippy` without warnings.
+* Pull requests need to be based on and opened against the `main` branch.
+* Commit messages should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, prefixed with the area they modify.
+  * E.g. "fix(name-service): point mainnet config at the deployed objects"
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more details on configuring your environment, managing project dependencies, and testing procedures.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ cd haneul
 cargo build --release
 ```
 
+## Executables
+
+The build produces a number of binaries, but these are the ones you are most likely to use:
+
+|       Command        | Description                                                                                                                                                                                                                                                                                            |
+| :------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|     **`haneul`**     | The main CLI. It bundles everything you need day to day: `haneul start` spins up a local network, `haneul client` is the wallet and RPC client, `haneul move` builds and tests Move packages, and `haneul keytool` manages keys. Run `haneul --help` for the full list of subcommands.                   |
+|    `haneul-node`     | The node daemon. It powers both validators and fullnodes; which role a node plays is determined by its configuration file.                                                                                                                                                                             |
+|   `haneul-faucet`    | HTTP service that hands out test HANEUL on local networks. You will rarely run it directly, as `haneul start --with-faucet` manages one for you.                                                                                                                                                        |
+|    `haneul-tool`     | Operational toolbox for node operators: database inspection, checkpoint and snapshot download, and network diagnostics.                                                                                                                                                                                |
+|   `haneul-bridge`    | The bridge node that relays assets between Haneul and Ethereum.                                                                                                                                                                                                                                        |
+| `haneul-indexer-alt` | Indexes chain data into Postgres and backs the GraphQL and JSON-RPC services.                                                                                                                                                                                                                          |
+
 ## Running a Local Node
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The surest path to reaching this goal was to start from technology that had alre
 
 ## Building from Source
 
+Building Haneul requires Rust and a handful of native dependencies. The workspace is large, so expect the first release build to take a while; incremental builds after that are much faster.
+
 ### 1. Install Rust
 
 ```bash
@@ -42,6 +44,8 @@ cd haneul
 cargo build --release
 ```
 
+The resulting binaries end up in `target/release`.
+
 ## Executables
 
 The build produces a number of binaries, but these are the ones you are most likely to use:
@@ -57,19 +61,21 @@ The build produces a number of binaries, but these are the ones you are most lik
 
 ## Running a Local Node
 
+The `haneul` binary can spin up a complete local network on your machine: a single validator with a faucet attached. This is the fastest way to try things out.
+
 ```bash
-# Start a local validator with faucet
 ./target/release/haneul start --with-faucet --force-regenesis
+```
 
-# Switch to local environment
+`--force-regenesis` starts from a fresh genesis every time, so nothing persists between runs. Once the node is up, open another terminal and point the client at your local network:
+
+```bash
 ./target/release/haneul client switch --env local
-
-# Get HANEUL tokens from faucet
 ./target/release/haneul client faucet
-
-# Check balance
 ./target/release/haneul client gas
 ```
+
+The faucet grants test HANEUL, and `client gas` lists the coin objects your address now owns.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Haneul's mission is to create a financial network built on trust, where hundreds
 
 The surest path to reaching this goal was to start from technology that had already been designed and proven to hold up at that scale. Haneul began its development based on the Sui codebase created by Mysten Labs, and has deep respect for their outstanding engineering.
 
+[![Github release](https://img.shields.io/github/v/release/GeunhwaJeong/haneul.svg?sort=semver)](https://github.com/GeunhwaJeong/haneul/releases/latest)
+[![License](https://img.shields.io/github/license/GeunhwaJeong/haneul)](https://github.com/GeunhwaJeong/haneul/blob/main/LICENSE)
+
 **Haneul is:**
 
 - **An object-centric blockchain**: Every asset is an object with an explicit owner, not a balance entry under an account. Transactions that touch disjoint objects execute in parallel, and transactions on single-owner objects are finalized without waiting for global ordering.
 - **Programmed in Move**: Smart contracts are written in Move, a language that guarantees at the type level that assets cannot be duplicated or accidentally destroyed.
 - **Secured by delegated proof of stake**: The DAG-based Mysticeti consensus provides sub-second finality. The native token HANEUL serves as both gas and the stake that secures the validator set.
 - **Built for everyday users**: The protocol supports zkLogin, so people can own on-chain assets with their existing web accounts, and sponsored transactions, so applications can pay gas on their users' behalf.
-
-[![Github release](https://img.shields.io/github/v/release/GeunhwaJeong/haneul.svg?sort=semver)](https://github.com/GeunhwaJeong/haneul/releases/latest)
-[![License](https://img.shields.io/github/license/GeunhwaJeong/haneul)](https://github.com/GeunhwaJeong/haneul/blob/main/LICENSE)
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ The surest path to reaching this goal was to start from technology that had alre
 - **Secured by delegated proof of stake**: The DAG-based Mysticeti consensus provides sub-second finality, with the native token HANEUL serving as both gas and stake.
 - **Built for everyday users**: The protocol supports zkLogin, for signing in with existing web accounts, and sponsored transactions, so applications can pay gas for their users.
 
+## Release Types
+
+There is currently one release track, with a clear purpose and version scheme:
+
+- **Mainnet Release**: production-ready releases running on the Haneul mainnet. Format: `mainnet-v<Major>.<Minor>.<Patch>`, example: [mainnet-v1.6.0](https://github.com/GeunhwaJeong/haneul/releases/tag/mainnet-v1.6.0).
+
+Devnet and testnet release tracks (`devnet-v<...>`, `testnet-v<...>`) are planned and will follow the same scheme.
+
 ## Building from Source
 
 Building Haneul requires Rust and a handful of native dependencies. The workspace is large, so expect the first release build to take a while; incremental builds after that are much faster.

--- a/README.md
+++ b/README.md
@@ -103,19 +103,6 @@ cargo fmt --all
 cargo xclippy
 ```
 
-## Project Structure
-
-The repository is one large Cargo workspace. A map of the places you are most likely to visit:
-
-```
-haneul/
-├── crates/                    # Core Rust crates (haneul-core, haneul-node, haneul-types, ...)
-├── consensus/                 # Mysticeti consensus engine
-├── haneul-execution/          # Move VM execution layer
-├── external-crates/           # Move compiler and VM
-└── bridge/                    # Cross-chain bridge
-```
-
 ## Contributing
 
 Thank you for considering helping out with the source code! We welcome contributions from anyone on the internet, and are grateful for even the smallest of fixes!


### PR DESCRIPTION
## Summary

Rewrites the root README from a bare command reference into a proper front page for the repository.

- Replace the one-line intro with a mission statement and an origin paragraph
- Add chain identity bullets (object-centric model, Move, delegated proof of stake, zkLogin and sponsored transactions)
- Add a Release Types section documenting the mainnet release track, with devnet and testnet tracks noted as planned
- Add an Executables table describing the main binaries
- Rewrite the build, local node, testing and linting sections with explanatory prose
- Expand the Contributing section with coding guidelines and PR conventions
- Drop the project structure tree and simplify the License section to a single line

## Test plan

- Rendered on the branch page and visually reviewed section by section
- All internal links (LICENSE, CONTRIBUTING.md, rust-toolchain.toml, release tag) resolve