### PR TITLE
ci: put the cargo target dir on the runner's second disk

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -68,6 +68,16 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force || true
           df -h /
+      - name: Put the cargo target dir on the second disk
+        run: |
+          # Even after cleanup the root disk cannot hold a full workspace
+          # build; /mnt has ~65GB nothing else uses. A symlink (rather than
+          # CARGO_TARGET_DIR) keeps hardcoded target/ paths such as
+          # check-determinism.sh working unchanged.
+          sudo mkdir -p /mnt/target
+          sudo chown "$USER" /mnt/target
+          ln -s /mnt/target target
+          df -h / /mnt
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:
@@ -98,6 +108,16 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force || true
+      - name: Put the cargo target dir on the second disk
+        run: |
+          # Even after cleanup the root disk cannot hold a full workspace
+          # build; /mnt has ~65GB nothing else uses. A symlink (rather than
+          # CARGO_TARGET_DIR) keeps hardcoded target/ paths such as
+          # check-determinism.sh working unchanged.
+          sudo mkdir -p /mnt/target
+          sudo chown "$USER" /mnt/target
+          ln -s /mnt/target target
+          df -h / /mnt
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:
@@ -128,6 +148,16 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force || true
+      - name: Put the cargo target dir on the second disk
+        run: |
+          # Even after cleanup the root disk cannot hold a full workspace
+          # build; /mnt has ~65GB nothing else uses. A symlink (rather than
+          # CARGO_TARGET_DIR) keeps hardcoded target/ paths such as
+          # check-determinism.sh working unchanged.
+          sudo mkdir -p /mnt/target
+          sudo chown "$USER" /mnt/target
+          ln -s /mnt/target target
+          df -h / /mnt
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,19 @@ jobs:
           sudo docker image prune --all --force || true
           df -h /
 
+      - name: Put the cargo target dir on the second disk (Ubuntu)
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        shell: bash
+        run: |
+          # Even after cleanup the root disk cannot hold a full release
+          # build; /mnt has ~65GB nothing else uses. A symlink keeps the
+          # target/release paths used by the packaging steps working
+          # unchanged.
+          sudo mkdir -p /mnt/target
+          sudo chown "$USER" /mnt/target
+          ln -s /mnt/target target
+          df -h / /mnt
+
       - name: Set Swap Space (Ubuntu)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master

--- a/.github/workflows/simtest-nightly.yml
+++ b/.github/workflows/simtest-nightly.yml
@@ -59,6 +59,16 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force || true
           df -h /
+      - name: Put the cargo target dir on the second disk
+        run: |
+          # Even after cleanup the root disk cannot hold a full workspace
+          # build; /mnt has ~65GB nothing else uses. A symlink (rather than
+          # CARGO_TARGET_DIR) keeps hardcoded target/ paths such as
+          # check-determinism.sh working unchanged.
+          sudo mkdir -p /mnt/target
+          sudo chown "$USER" /mnt/target
+          ln -s /mnt/target target
+          df -h / /mnt
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:
@@ -92,6 +102,16 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force || true
           df -h /
+      - name: Put the cargo target dir on the second disk
+        run: |
+          # Even after cleanup the root disk cannot hold a full workspace
+          # build; /mnt has ~65GB nothing else uses. A symlink (rather than
+          # CARGO_TARGET_DIR) keeps hardcoded target/ paths such as
+          # check-determinism.sh working unchanged.
+          sudo mkdir -p /mnt/target
+          sudo chown "$USER" /mnt/target
+          ln -s /mnt/target target
+          df -h / /mnt
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:


### PR DESCRIPTION
## Description

The first runs of Full Tests and Simulator Tests (after #34) all failed with `No space left on device`: the runner's root disk cannot hold a full workspace build even after cleanup. Hosted runners have a second ~65GB disk at `/mnt` that nothing uses, so the ubuntu jobs now symlink `target` -> `/mnt/target` before building. A symlink rather than `CARGO_TARGET_DIR` keeps hardcoded `target/` paths (`check-determinism.sh`, the release packaging steps) working unchanged. Also applied preemptively to the ubuntu legs of the release build, which would hit the same wall.

## Test plan

Verified locally that a `target` symlink is ignored by git (`.gitignore` uses `**/target`), so the `changed-files.sh` check is unaffected. Real validation is re-running Full Tests and Simulator Tests via workflow_dispatch after merge.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: