### PR TITLE
ci: run the heavy test workflows on demand only

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -1,12 +1,12 @@
 name: Full Tests
 
 # Heavy lane: the full workspace test suite, storage-backend variant tests,
-# doc/schema checks, and the windows build. Too big to run on every PR with
-# standard hosted runners, so it runs weekly against main and on demand
-# (always run it via workflow_dispatch before cutting a release).
+# doc/schema checks, and the windows build. The linux jobs currently exceed
+# hosted-runner disk and memory, so there is no schedule; this exists for
+# on-demand runs (and as the place to resume if larger runners ever become
+# available). The release safety net is the local simtest pass done before
+# every release tag.
 on:
-  schedule:
-    - cron: '0 17 * * 0' # 2am KST on Mondays
   workflow_dispatch:
     inputs:
       haneul_repo_ref:

--- a/.github/workflows/simtest-nightly.yml
+++ b/.github/workflows/simtest-nightly.yml
@@ -2,12 +2,11 @@ name: Simulator Tests
 
 # The deterministic simulator suite is the highest-value test lane for a
 # blockchain node: it exercises consensus, epoch change, and crash recovery
-# under a seeded scheduler. It does not fit hosted runners on every PR, so it
-# runs twice a week against main and on demand (always run it via
-# workflow_dispatch before cutting a release).
+# under a seeded scheduler. It currently exceeds hosted-runner disk and
+# memory, so there is no schedule; this exists for on-demand runs. The
+# release safety net is the local simtest pass done before every release
+# tag.
 on:
-  schedule:
-    - cron: '0 17 * * 2,5' # 2am KST on Wednesdays and Saturdays
   workflow_dispatch:
     inputs:
       haneul_repo_ref:


### PR DESCRIPTION
## Description

The linux jobs of Full Tests and Simulator Tests exceed free hosted-runner disk and memory (#34, #35), so their schedules would only produce a red failure on every tick. Drop the crons and keep both workflows dispatch-only. The release safety net remains the local simtest pass done before every release tag.

## Test plan

Workflow-file-only change; both files pass YAML parsing.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: