### PR TITLE
docs: fix haneul-http callback doctest imports

### DIFF
--- a/crates/haneul-http/src/middleware/callback/mod.rs
+++ b/crates/haneul-http/src/middleware/callback/mod.rs
@@ -21,10 +21,10 @@
 //! ```
 //! use http::request;
 //! use http::response;
-//! use sui_http::middleware::callback::CallbackLayer;
-//! use sui_http::middleware::callback::MakeCallbackHandler;
-//! use sui_http::middleware::callback::RequestHandler;
-//! use sui_http::middleware::callback::ResponseHandler;
+//! use haneul_http::middleware::callback::CallbackLayer;
+//! use haneul_http::middleware::callback::MakeCallbackHandler;
+//! use haneul_http::middleware::callback::RequestHandler;
+//! use haneul_http::middleware::callback::ResponseHandler;
 //!
 //! /// A handler that counts bytes observed on one side of the exchange.
 //! #[derive(Default)]


### PR DESCRIPTION
## Description

The compiled doctest in the callback middleware imported a crate path that does not exist in this workspace, so the `cargo test --doc` lane failed to build `haneul-http`.

## Test plan

`cargo test --doc -p haneul-http` now builds and passes (2 passed, 1 ignored).

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 