### PR TITLE
chore: bump workspace version to 1.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,7 +2813,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "const-str",
  "git-version",
@@ -6467,7 +6467,7 @@ dependencies = [
 
 [[package]]
 name = "haneul"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6732,7 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-analytics-indexer"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -6791,7 +6791,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-analytics-indexer-derive"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6864,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-bridge"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy",
  "alloy-multiprovider-strategy",
@@ -6923,7 +6923,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-bridge-cli"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7019,7 +7019,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-checkpoint-blob-indexer"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-cluster-test"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7115,7 +7115,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-consistent-store"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7363,7 +7363,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-display"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7387,7 +7387,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-e2e-tests"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7558,7 +7558,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-faucet"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -7586,14 +7586,14 @@ dependencies = [
 
 [[package]]
 name = "haneul-field-count"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "haneul-field-count-derive",
 ]
 
 [[package]]
 name = "haneul-field-count-derive"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -7601,7 +7601,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-fork"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7660,7 +7660,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-framework-snapshot"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7704,7 +7704,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-futures"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -7766,7 +7766,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7798,7 +7798,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-consistent-api"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -7811,7 +7811,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-consistent-store"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-framework"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7984,7 +7984,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-framework-store-traits"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7996,7 +7996,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-graphql"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8065,7 +8065,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-jsonrpc"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8126,7 +8126,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-metrics"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -8141,7 +8141,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-object-store"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-reader"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -8193,7 +8193,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-indexer-alt-schema"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8209,7 +8209,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-inverted-index"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8426,7 +8426,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-kv-rpc"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-kvstore"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-light-client"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8575,7 +8575,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-metric-checker"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-move"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -8659,7 +8659,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-move-build"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -8685,7 +8685,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-move-lsp"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bin-version",
  "clap",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-name-service"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bcs",
  "haneul-types",
@@ -8867,7 +8867,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-node"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -8927,7 +8927,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-open-rpc"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8961,7 +8961,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-oracle"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8991,7 +8991,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-package-alt"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9010,7 +9010,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-package-dump"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9026,7 +9026,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-package-management"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "haneul-framework-snapshot",
@@ -9059,7 +9059,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-pg-db"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9099,7 +9099,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-prompt"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rosetta"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9397,7 +9397,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-benchmark"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "bb8",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-loadgen"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9461,7 +9461,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-resolver"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9480,7 +9480,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-rpc-store"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9512,7 +9512,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-sdk"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9576,7 +9576,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-security-watchdog"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9624,7 +9624,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-single-node-benchmark"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bcs",
  "clap",
@@ -9683,7 +9683,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-source-verification"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -9729,7 +9729,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-sql-macro"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -9795,7 +9795,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-surfer"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bcs",
  "clap",
@@ -9908,7 +9908,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-test-validator"
-version = "1.7.0"
+version = "1.7.1"
 
 [[package]]
 name = "haneul-tls"
@@ -9934,7 +9934,7 @@ dependencies = [
 
 [[package]]
 name = "haneul-tool"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -20485,7 +20485,7 @@ dependencies = [
 
 [[package]]
 name = "x"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,7 +230,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by haneul-core, haneul-faucet, haneul-node, haneul-tools, haneul-sdk, haneul-move-build, and haneul crates.
-version = "1.7.0"
+version = "1.7.1"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/haneul-open-rpc/spec/openrpc.json
+++ b/crates/haneul-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/HaneulLabs/haneul/main/LICENSE"
     },
-    "version": "1.77.2"
+    "version": "1.7.1"
   },
   "methods": [
     {

--- a/crates/haneul-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
+++ b/crates/haneul-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/HaneulLabs/haneul/main/LICENSE"
     },
-    "version": "1.7.0"
+    "version": "1.7.1"
   },
   "methods": [
     {


### PR DESCRIPTION
## Description

Patch release for the maintenance batch on main since v1.7.0: the h2 security update (RUSTSEC-2026-0258, #40), the bridge encoding and signature fixture regeneration (#39), the deny.toml source allow list fix (#38), and the haneul-http doctest fix (#37). No protocol change; the network stays on protocol version 122.

Produced by `scripts/version-bump.sh --type patch`. This also aligns the openrpc spec version string with the workspace version scheme (it previously carried a stale 1.77.2).

## Test plan

- The bump script's built-in full-workspace `cargo check` passed.
- `cargo nextest run -p haneul-open-rpc`: 2 passed, including the spec snapshot test against the updated version string.

---

## Release notes

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Version 1.7.1 is a maintenance release (dependency security update for h2, test and tooling fixes). No protocol or behavior change; upgrading is routine.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 